### PR TITLE
Parse histogram labels

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default function parsePrometheusTextFormat(metrics) {
                         }
                         lineType = remain.toUpperCase();
                     }
-                } else {
+                } else if (instr === 2) {
                     throw new InvalidLineError(line);
                 }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -162,32 +162,61 @@ export default function parsePrometheusTextFormat(metrics) {
 }
 
 function flattenMetrics(metrics, groupName, keyName, valueName) {
+    const result = [];
     let flattened = null;
+    let lastKey = null;
+
     for (let i = 0; i < metrics.length; ++i) {
         const sample = metrics[i];
-        if (sample.labels && sample.labels[keyName] && sample[valueName]) {
-            if (!flattened) {
-                flattened = {};
-                flattened[groupName] = {};
+        const labels = sample.labels || {};
+        const otherLabels = excludeKey(labels, keyName);
+        const currentKey = JSON.stringify(otherLabels);
+
+        if (currentKey !== lastKey) {
+            lastKey = currentKey;
+            flattened = null;
+        }
+
+        if (!flattened) {
+            flattened = {};
+            flattened[groupName] = {};
+            if (Object.keys(otherLabels).length) {
+                flattened.labels = otherLabels;
             }
-            flattened[groupName][sample.labels[keyName]] = sample[valueName];
-        } else if (!sample.labels) {
-            if (!flattened) {
-                flattened = {};
-            }
-            if (sample.count !== undefined) {
-                flattened.count = sample.count;
-            }
-            if (sample.sum !== undefined) {
-                flattened.sum = sample.sum;
-            }
+
+            result.push(flattened);
+        }
+
+        if (labels[keyName] !== undefined && sample[valueName] !== undefined) {
+            flattened[groupName][labels[keyName]] = sample[valueName];
+        }
+        if (sample.count !== undefined) {
+            flattened.count = sample.count;
+        }
+        if (sample.sum !== undefined) {
+            flattened.sum = sample.sum;
         }
     }
-    if (flattened) {
-        return [flattened];
-    } else {
-        return metrics;
+
+    return result;
+}
+
+/** Returns an object with the given key excluded */
+function excludeKey(object, key) {
+    if (!object) {
+        return labels;
     }
+
+    const result = {};
+
+    Object.keys(object)
+        .forEach(currentKey => {
+            if (currentKey !== key) {
+                result[currentKey] = object[currentKey];
+            }
+        });
+
+    return result;
 }
 
 // adapted from https://github.com/prometheus/client_python/blob/0.0.19/prometheus_client/parser.py

--- a/test/expected-output.json
+++ b/test/expected-output.json
@@ -1,1 +1,142 @@
-[{"name":"http_request_duration_seconds","help":"A histogram of the request duration.","type":"HISTOGRAM","metrics":[{"buckets":{"+Inf":"144320","0.05":"24054","0.1":"33444","0.2":"100392","0.5":"129389","1":"133988"},"count":"144320","sum":"53423"}]},{"name":"rpc_duration_seconds","help":"A summary of the RPC duration in seconds.","type":"SUMMARY","metrics":[{"quantiles":{"0.01":"3102","0.05":"3272","0.5":"4773","0.9":"9001","0.99":"76656"},"count":"2693","sum":"1.7560473e+07"}]},{"name":"jvm_gc_collection_seconds","help":"Time spent in a given JVM garbage collector in seconds.","type":"SUMMARY","metrics":[{"labels":{"gc":"Copy"},"count":"104","sum":"0.491"},{"labels":{"gc":"MarkSweepCompact"},"count":"12","sum":"0.486"}]},{"name":"jvm_classes_loaded","help":"The number of classes that are currently loaded in the JVM","type":"GAUGE","metrics":[{"value":"3851"}]},{"name":"http_requests_total","help":"The total number of HTTP requests.","type":"COUNTER","metrics":[{"labels":{"code":"200","method":"post"},"timestamp_ms":"1395066363000","value":"1027"},{"labels":{"code":"400","method":"post"},"timestamp_ms":"1395066363000","value":"3"}]},{"name":"msdos_file_access_time_seconds","help":"","type":"UNTYPED","metrics":[{"labels":{"error":"Cannot find file:\n\"FILE.TXT\"","path":"C:\\DIR\\FILE.TXT"},"value":"1.458255915e+09"}]},{"name":"metric_without_timestamp_and_labels","help":"","type":"UNTYPED","metrics":[{"value":"12.47"}]},{"name":"something_weird","help":"","type":"UNTYPED","metrics":[{"labels":{"problem":"division by zero"},"timestamp_ms":"-3982045","value":"+Inf"}]},{"name":"myprogram_runtime_gc_pause_ns","help":"myprogram_runtime_gc_pause_ns","type":"SUMMARY","metrics":[{"count":"3","sum":"91900"}]}]
+[
+  {
+    "name": "http_request_duration_seconds",
+    "help": "A histogram of the request duration.",
+    "type": "HISTOGRAM",
+    "metrics": [
+      {
+        "buckets": {
+          "+Inf": "144320",
+          "0.05": "24054",
+          "0.1": "33444",
+          "0.2": "100392",
+          "0.5": "129389",
+          "1": "133988"
+        },
+        "count": "144320",
+        "sum": "53423"
+      }
+    ]
+  },
+  {
+    "name": "rpc_duration_seconds",
+    "help": "A summary of the RPC duration in seconds.",
+    "type": "SUMMARY",
+    "metrics": [
+      {
+        "quantiles": {
+          "0.01": "3102",
+          "0.05": "3272",
+          "0.5": "4773",
+          "0.9": "9001",
+          "0.99": "76656"
+        },
+        "count": "2693",
+        "sum": "1.7560473e+07"
+      }
+    ]
+  },
+  {
+    "name": "jvm_gc_collection_seconds",
+    "help": "Time spent in a given JVM garbage collector in seconds.",
+    "type": "SUMMARY",
+    "metrics": [
+      {
+        "labels": {
+          "gc": "Copy"
+        },
+        "count": "104",
+        "sum": "0.491"
+      },
+      {
+        "labels": {
+          "gc": "MarkSweepCompact"
+        },
+        "count": "12",
+        "sum": "0.486"
+      }
+    ]
+  },
+  {
+    "name": "jvm_classes_loaded",
+    "help": "The number of classes that are currently loaded in the JVM",
+    "type": "GAUGE",
+    "metrics": [
+      {
+        "value": "3851"
+      }
+    ]
+  },
+  {
+    "name": "http_requests_total",
+    "help": "The total number of HTTP requests.",
+    "type": "COUNTER",
+    "metrics": [
+      {
+        "labels": {
+          "code": "200",
+          "method": "post"
+        },
+        "timestamp_ms": "1395066363000",
+        "value": "1027"
+      },
+      {
+        "labels": {
+          "code": "400",
+          "method": "post"
+        },
+        "timestamp_ms": "1395066363000",
+        "value": "3"
+      }
+    ]
+  },
+  {
+    "name": "msdos_file_access_time_seconds",
+    "help": "",
+    "type": "UNTYPED",
+    "metrics": [
+      {
+        "labels": {
+          "error": "Cannot find file:\n\"FILE.TXT\"",
+          "path": "C:\\DIR\\FILE.TXT"
+        },
+        "value": "1.458255915e+09"
+      }
+    ]
+  },
+  {
+    "name": "metric_without_timestamp_and_labels",
+    "help": "",
+    "type": "UNTYPED",
+    "metrics": [
+      {
+        "value": "12.47"
+      }
+    ]
+  },
+  {
+    "name": "something_weird",
+    "help": "",
+    "type": "UNTYPED",
+    "metrics": [
+      {
+        "labels": {
+          "problem": "division by zero"
+        },
+        "timestamp_ms": "-3982045",
+        "value": "+Inf"
+      }
+    ]
+  },
+  {
+    "name": "myprogram_runtime_gc_pause_ns",
+    "help": "myprogram_runtime_gc_pause_ns",
+    "type": "SUMMARY",
+    "metrics": [
+      {
+        "count": "3",
+        "sum": "91900"
+      }
+    ]
+  }
+]

--- a/test/expected-output.json
+++ b/test/expected-output.json
@@ -159,5 +159,15 @@
         "sum": "91900"
       }
     ]
+  },
+  {
+    "name": "metric_without_help",
+    "help": "",
+    "type": "COUNTER",
+    "metrics": [
+      {
+        "value": "0"
+      }
+    ]
   }
 ]

--- a/test/expected-output.json
+++ b/test/expected-output.json
@@ -5,6 +5,9 @@
     "type": "HISTOGRAM",
     "metrics": [
       {
+        "labels": {
+          "status": "success"
+        },
         "buckets": {
           "+Inf": "144320",
           "0.05": "24054",
@@ -15,6 +18,21 @@
         },
         "count": "144320",
         "sum": "53423"
+      },
+      {
+        "labels": {
+          "status": "failure"
+        },
+        "buckets": {
+          "+Inf": "6",
+          "0.05": "1",
+          "0.1": "2",
+          "0.2": "3",
+          "0.5": "4",
+          "1": "5"
+        },
+        "count": "6",
+        "sum": "10"
       }
     ]
   },
@@ -45,6 +63,7 @@
         "labels": {
           "gc": "Copy"
         },
+        "quantiles": {},
         "count": "104",
         "sum": "0.491"
       },
@@ -52,6 +71,7 @@
         "labels": {
           "gc": "MarkSweepCompact"
         },
+        "quantiles": {},
         "count": "12",
         "sum": "0.486"
       }
@@ -134,6 +154,7 @@
     "type": "SUMMARY",
     "metrics": [
       {
+        "quantiles": {},
         "count": "3",
         "sum": "91900"
       }

--- a/test/input.txt
+++ b/test/input.txt
@@ -59,3 +59,7 @@ jvm_gc_collection_seconds_count{gc="Copy",} 104.0
 jvm_gc_collection_seconds_sum{gc="Copy",} 0.491
 jvm_gc_collection_seconds_count{gc="MarkSweepCompact",} 12.0
 jvm_gc_collection_seconds_sum{gc="MarkSweepCompact",} 0.486
+
+# HELP metric_without_help
+# TYPE metric_without_help counter
+metric_without_help 0

--- a/test/input.txt
+++ b/test/input.txt
@@ -19,14 +19,22 @@ something_weird{problem="division by zero"} +Inf -3982045
 # A histogram, which has a pretty complex representation in the text format:
 # HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
-http_request_duration_seconds_bucket{le="0.05"} 24054
-http_request_duration_seconds_bucket{le="0.1"} 33444
-http_request_duration_seconds_bucket{le="0.2"} 100392
-http_request_duration_seconds_bucket{le="0.5"} 129389
-http_request_duration_seconds_bucket{le="1"} 133988
-http_request_duration_seconds_bucket{le="+Inf"} 144320
-http_request_duration_seconds_sum 53423
-http_request_duration_seconds_count 144320
+http_request_duration_seconds_bucket{status="success",le="0.05"} 24054
+http_request_duration_seconds_bucket{status="success",le="0.1"} 33444
+http_request_duration_seconds_bucket{status="success",le="0.2"} 100392
+http_request_duration_seconds_bucket{status="success",le="0.5"} 129389
+http_request_duration_seconds_bucket{status="success",le="1"} 133988
+http_request_duration_seconds_bucket{status="success",le="+Inf"} 144320
+http_request_duration_seconds_sum{status="success"} 53423
+http_request_duration_seconds_count{status="success"} 144320
+http_request_duration_seconds_bucket{status="failure",le="0.05"} 1
+http_request_duration_seconds_bucket{status="failure",le="0.1"} 2
+http_request_duration_seconds_bucket{status="failure",le="0.2"} 3
+http_request_duration_seconds_bucket{status="failure",le="0.5"} 4
+http_request_duration_seconds_bucket{status="failure",le="1"} 5
+http_request_duration_seconds_bucket{status="failure",le="+Inf"} 6
+http_request_duration_seconds_sum{status="failure"} 10
+http_request_duration_seconds_count{status="failure"} 6
 
 # Finally a summary, which has a complex representation, too:
 # HELP rpc_duration_seconds A summary of the RPC duration in seconds.

--- a/test/run-test.js
+++ b/test/run-test.js
@@ -23,7 +23,7 @@ if (process.argv[2] === 'bench') {
     const actual = sortPromJSON(
         normalizeNumberValues(parsePrometheusTextFormat(inputStr))
     );
-    assert.deepEqual(expected, actual);
+    assert.deepEqual(actual, expected);
     console.log('Test OK');
 }
 


### PR DESCRIPTION
Fixes label support for histogram and summary metrics
Fixes histograms with a "0" bucket having that bucket skipped
Fixes histograms with a bucket with a "0" value having that bucket skipped
Fixes error when metrics have blank HELP text