### PR TITLE
Fixing rare case for summaries without non-quantile label

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,8 @@ function flattenMetrics(metrics, groupName, keyName, valueName) {
         if (sample.labels && sample.labels[keyName] && sample[valueName]) {
             if (!flattened) {
                 flattened = {};
+            }
+            if (!flattened[groupName]) {
                 flattened[groupName] = {};
             }
             flattened[groupName][sample.labels[keyName]] = sample[valueName];


### PR DESCRIPTION
It noticed a special case in Prometheus looking like this
```
# TYPE my_fancy_metric summary
my_fancy_metric_count 23
my_fancy_metric_sum 42
my_fancy_metric{quantile="0.5"} 0.2
my_fancy_metric{quantile="0.9"} 0.1
my_fancy_metric{quantile="0.95"} 0.05
my_fancy_metric{quantile="0.99"} 0.02
```
results in a run time error as first the `count` and `sum` are handled which creates the `flattened` struct. Because of this the line `flattened[groupName] = {}` is not executed later (as only for `flattened` is checked, not for `flattened[groupName] = {}`) although it us accessed right after.